### PR TITLE
Fix missing import in core.py

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, json, ssl, socket, datetime, requests, logging
+import os, json, ssl, socket, datetime, requests, logging, time
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 


### PR DESCRIPTION
## Summary
- add missing `time` import in `core.py`

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_683f547d69a4832e8b310cca9d9d2fe1