### PR TITLE
Add pytest and basic site tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+**/__pycache__/
+*.pyc
+.pytest_cache/
+

--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ cd telegram-site-monitor
 cp .env.example .env  # insert your BOT_TOKEN and CHAT_ID
 
 docker compose up --build -d
+```
+
+### Running tests
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot==13.15
 requests
 python-dotenv
+pytest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import core
+
+def test_save_and_load_sites(tmp_path, monkeypatch):
+    tmp_file = tmp_path / "sites.txt"
+    monkeypatch.setattr(core, "SITES_FILE", str(tmp_file))
+
+    # initially file does not exist
+    assert core.load_sites() == []
+
+    data = ["https://example.com", "https://google.com"]
+    core.save_sites(data)
+    assert tmp_file.exists()
+
+    loaded = core.load_sites()
+    assert loaded == data


### PR DESCRIPTION
## Summary
- add pytest dependency
- write unit test for save/load sites
- document running tests
- add gitignore for caches

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f563ac580832eaff31b3928f5d4f8