### PR TITLE
Add pytest and basic site tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+**/__pycache__/
+*.pyc
+.pytest_cache/
+

--- a/README.md
+++ b/README.md
@@ -47,3 +47,25 @@ cd telegram-site-monitor
 cp .env.example .env  # insert your BOT_TOKEN and CHAT_ID
 
 docker compose up --build -d
+```
+
+### Configuration
+
+Update `.env` with your bot credentials:
+
+```env
+BOT_TOKEN=your_bot_token
+CHAT_ID=your_chat_id
+```
+
+Add starting URLs to `sites.txt` or manage them via Telegram commands:
+`/add`, `/remove` and `/list`.
+
+Logs are written to `./logs/monitor.log` for external analysis.
+
+### Running tests
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot==13.15
 requests
 python-dotenv
+pytest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import core
+
+def test_save_and_load_sites(tmp_path, monkeypatch):
+    tmp_file = tmp_path / "sites.txt"
+    monkeypatch.setattr(core, "SITES_FILE", str(tmp_file))
+
+    # initially file does not exist
+    assert core.load_sites() == []
+
+    data = ["https://example.com", "https://google.com"]
+    core.save_sites(data)
+    assert tmp_file.exists()
+
+    loaded = core.load_sites()
+    assert loaded == data
+
+
+def test_send_alert_disable_preview(monkeypatch):
+    monkeypatch.setattr(core, "BOT_TOKEN", "TEST")
+    monkeypatch.setattr(core, "CHAT_ID", "1")
+
+    captured = {}
+
+    def fake_post(url, data=None, timeout=5):
+        captured['url'] = url
+        captured['data'] = data
+        captured['timeout'] = timeout
+        class Resp:
+            pass
+        return Resp()
+
+    monkeypatch.setattr(core.requests, "post", fake_post)
+    core.send_alert("hello")
+
+    assert captured['data']["disable_web_page_preview"] is True


### PR DESCRIPTION
## Summary
- add pytest dependency
- write unit test for save/load sites
- document running tests
- document configuration in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f563ac580832eaff31b3928f5d4f8