### PR TITLE
Fix Bot creation race

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, json, ssl, socket, datetime, requests, logging, time
+import os, json, ssl, socket, datetime, requests, logging, time, threading
 from telegram import Bot
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
@@ -21,13 +21,15 @@ def log_event(data: dict):
     logging.info(json.dumps(data))
 
 _bot = None
+_bot_lock = threading.Lock()
 
 
 def _get_bot():
     global _bot
-    if _bot is None:
-        _bot = Bot(BOT_TOKEN)
-    return _bot
+    with _bot_lock:
+        if _bot is None:
+            _bot = Bot(BOT_TOKEN)
+        return _bot
 
 
 def send_alert(msg, disable_web_page_preview=True):


### PR DESCRIPTION
## Summary
- protect `core._get_bot` with a lock
- test that concurrent `_get_bot` calls create only one instance

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840aacabafc832e948b40e48fa9476a